### PR TITLE
chore: add .gitignore for Anchor/Rust/Node toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# ─── Rust / Anchor ─────────────────────────────────────────
+target/
+**/*.rs.bk
+Cargo.lock
+.anchor/
+test-ledger/
+.crates.toml
+.crates2.json
+
+# ─── Node / TypeScript ─────────────────────────────────────
+node_modules/
+dist/
+build/
+.next/
+out/
+*.tsbuildinfo
+.npm/
+.pnpm-store/
+.yarn/
+
+# ─── Env / secrets ─────────────────────────────────────────
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+id_*.json
+keypair*.json
+wallet*.json
+
+# ─── Logs / coverage ───────────────────────────────────────
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+coverage/
+.nyc_output/
+
+# ─── Editor / OS ───────────────────────────────────────────
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# ─── Misc ──────────────────────────────────────────────────
+tmp/
+*.tmp
+.cache/


### PR DESCRIPTION
Adds a baseline .gitignore covering Anchor build artifacts, Rust target dirs, Node modules, environment files, keypairs, logs, and editor cruft.

Establishes the repo's hygiene rules before any source lands.